### PR TITLE
PIN-852 - added PDND logger layout to commons lib

### DIFF
--- a/utils/src/main/scala/it/pagopa/pdnd/interop/commons/utils/LoggerLayout.scala
+++ b/utils/src/main/scala/it/pagopa/pdnd/interop/commons/utils/LoggerLayout.scala
@@ -1,0 +1,34 @@
+package it.pagopa.pdnd.interop.commons.utils
+
+import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.CoreConstants
+import ch.qos.logback.core.util.CachingDateFormatter
+
+/** Defines the Logback Pattern Layout for PDND Interop
+  */
+final class LoggerLayout extends PatternLayout {
+
+  val cachingDateFormatter = new CachingDateFormatter("yyyy-MM-dd HH:mm:ss.SSS")
+
+  final val EMPTY_SPACE = " "
+
+  override def doLayout(event: ILoggingEvent): String = {
+    val sbuf = new StringBuffer(128)
+    sbuf.append(cachingDateFormatter.format(event.getTimeStamp))
+    sbuf.append(EMPTY_SPACE)
+    sbuf.append(withinBrackets(buildinfo.BuildInfo.name))
+    sbuf.append(EMPTY_SPACE)
+    sbuf.append(event.getLevel)
+    sbuf.append(EMPTY_SPACE)
+    sbuf.append(withinBrackets(event.getThreadName))
+    sbuf.append(EMPTY_SPACE)
+    sbuf.append(withinBrackets(event.getLoggerName))
+    sbuf.append(" - ")
+    sbuf.append(event.getFormattedMessage())
+    sbuf.append(CoreConstants.LINE_SEPARATOR)
+    sbuf.toString()
+  }
+
+  private def withinBrackets(str: String) = s"[$str]"
+}


### PR DESCRIPTION
This defines a custom pattern layout for Logback that is more aligned with the requirements of selfcare. It contains all the attributes but the ones that should go in MDC (i.e.: user id).