### PR TITLE
pin-2302: Add organization id to log messages

### DIFF
--- a/jwt/src/main/scala/it/pagopa/interop/commons/jwt/package.scala
+++ b/jwt/src/main/scala/it/pagopa/interop/commons/jwt/package.scala
@@ -122,8 +122,9 @@ package object jwt {
     val values: Map[String, String] = contexts.toMap
     val ipAddress: String           = values.getOrElse(IP_ADDRESS, "")
     val uid: String                 = values.get(UID).filterNot(_.isBlank).orElse(values.get(SUB)).getOrElse("")
+    val organizationId: String      = values.getOrElse(ORGANIZATION_ID_CLAIM, "")
     val correlationId: String       = values.getOrElse(CORRELATION_ID_HEADER, "")
-    val header: String              = s"[IP=$ipAddress] [UID=$uid] [CID=$correlationId]"
+    val header: String              = s"[IP=$ipAddress] [UID=$uid] [OID=$organizationId] [CID=$correlationId]"
     val body: String                = values
       .get(USER_ROLES)
       .fold(s"No user roles found to execute this request")(roles =>

--- a/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizeLazynessSpec.scala
+++ b/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizeLazynessSpec.scala
@@ -1,6 +1,5 @@
 package it.pagopa.interop.commons.jwt
 
-import it.pagopa.interop.commons.jwt._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest

--- a/utils/src/main/scala/it/pagopa/interop/commons/logging/logging.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/logging/logging.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.CanLog
-import it.pagopa.interop.commons.utils.{CORRELATION_ID_HEADER, IP_ADDRESS, SUB, UID}
+import it.pagopa.interop.commons.utils.{CORRELATION_ID_HEADER, IP_ADDRESS, ORGANIZATION_ID_CLAIM, SUB, UID}
 
 import java.util.UUID
 
@@ -22,10 +22,11 @@ package object logging {
     else false
 
   private def createLogContexts(values: Map[String, String]): String = {
-    val ipAddress: String     = values.getOrElse(IP_ADDRESS, "")
-    val uid: String           = values.get(UID).filterNot(_.isBlank).orElse(values.get(SUB)).getOrElse("")
-    val correlationId: String = values.getOrElse(CORRELATION_ID_HEADER, "")
-    s"[IP=$ipAddress] [UID=$uid] [CID=$correlationId]"
+    val ipAddress: String      = values.getOrElse(IP_ADDRESS, "")
+    val uid: String            = values.get(UID).filterNot(_.isBlank).orElse(values.get(SUB)).getOrElse("")
+    val organizationId: String = values.getOrElse(ORGANIZATION_ID_CLAIM, "")
+    val correlationId: String  = values.getOrElse(CORRELATION_ID_HEADER, "")
+    s"[IP=$ipAddress] [UID=$uid] [OID=$organizationId] [CID=$correlationId]"
   }
 
   /** Defines log message decoration for Interop


### PR DESCRIPTION
I kept current naming `xID` (e.g. `UID` or `CID`), let me know if you prefer something more self explaining like `ORGID`