### PR TITLE
pin-2210: Centralized error handling

### DIFF
--- a/jwt/src/main/scala/it/pagopa/interop/commons/jwt/service/JWTReader.scala
+++ b/jwt/src/main/scala/it/pagopa/interop/commons/jwt/service/JWTReader.scala
@@ -82,11 +82,11 @@ trait JWTReader {
               case "Bearer" :: payload :: Nil =>
                 validation.andThen(authenticationDirective(contextInfo))(payload)
               case _                          =>
-                logger.error(s"$contextInfo - No authentication has been provided for this call")
+                logger.warn(s"$contextInfo - No authentication has been provided for this call")
                 reject(MalformedHeaderRejection("Authorization", "Illegal header key."))
             }
           case None         =>
-            logger.error(s"$contextInfo - No authentication has been provided for this call")
+            logger.warn(s"$contextInfo - No authentication has been provided for this call")
             reject(AuthenticationFailedRejection(CredentialsMissing, HttpChallenge("Bearer", None)))
         }
       }
@@ -96,7 +96,7 @@ trait JWTReader {
   private def authenticationDirective[T](contextInfo: String): Try[T] => Directive1[T] = {
     case Success(result) => provide(result)
     case Failure(ex)     =>
-      logger.error(s"$contextInfo - Invalid authentication provided - ${ex.getMessage}")
+      logger.warn(s"$contextInfo - Invalid authentication provided - ${ex.getMessage}")
       reject(AuthenticationFailedRejection(CredentialsRejected, HttpChallenge("Bearer", None)))
   }
 }

--- a/jwt/src/main/scala/it/pagopa/interop/commons/jwt/service/impl/DefaultClientAssertionValidator.scala
+++ b/jwt/src/main/scala/it/pagopa/interop/commons/jwt/service/impl/DefaultClientAssertionValidator.scala
@@ -33,12 +33,12 @@ trait DefaultClientAssertionValidator extends ClientAssertionValidator {
   private def subjectClaim(clientId: Option[String], claimSet: JWTClaimsSet): Try[String] = {
     Try(claimSet.getSubject) match {
       case Failure(_) =>
-        logger.error("Subject not found in this claim")
+        logger.warn("Subject not found in this claim")
         Failure(SubjectNotFound)
 
       case Success(s) if s == clientId.getOrElse(s) => Success(s)
       case Success(s)                               =>
-        logger.error(s"Subject value $s is not equal to the provided client_id $clientId")
+        logger.warn(s"Subject value $s is not equal to the provided client_id $clientId")
         Failure(InvalidSubject(s))
     }
   }

--- a/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizationSpec.scala
+++ b/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizationSpec.scala
@@ -3,7 +3,6 @@ package it.pagopa.interop.commons.jwt
 import akka.http.scaladsl.server.Directives.{complete, get}
 import akka.http.scaladsl.server.Route
 import it.pagopa.interop.commons.utils.USER_ROLES
-//import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -14,7 +13,7 @@ import it.pagopa.interop.commons.utils.errors.ServiceCode
 
 import scala.annotation.nowarn
 
-class AuthorizeLazynessSpec extends AnyWordSpecLike with Matchers with ScalatestRouteTest {
+class AuthorizationSpec extends AnyWordSpecLike with Matchers with ScalatestRouteTest {
 
   implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)

--- a/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizeLazynessSpec.scala
+++ b/jwt/src/test/scala/it/pagopa/interop/commons/jwt/AuthorizeLazynessSpec.scala
@@ -1,30 +1,68 @@
 package it.pagopa.interop.commons.jwt
 
-import it.pagopa.interop.commons.jwt._
+import akka.http.scaladsl.server.Directives.{complete, get}
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.server.Directives._
+import it.pagopa.interop.commons.utils.USER_ROLES
+//import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
+import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
+import it.pagopa.interop.commons.utils.errors.ServiceCode
+
 import scala.annotation.nowarn
 
 class AuthorizeLazynessSpec extends AnyWordSpecLike with Matchers with ScalatestRouteTest {
+
+  implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+    Logger.takingImplicit[ContextFieldsToLog](this.getClass)
+  implicit val serviceCode: ServiceCode                         = ServiceCode("000")
 
   "Authorization method should be lazy and not consume the route definition eagerly" in {
     implicit val contexts: List[(String, String)] = List()
 
     @nowarn
     def route: Route = {
-      failTest("authorizeInterop is no more lazy")
+      failTest("authorize is no more lazy")
       get { complete("OK") }
     }
 
-    val routeToTest: Route = authorizeInterop[String](false, "You should see this")(route)
+    val routeToTest: Route = authorize("role1")(route)
 
     Get() ~> routeToTest ~> check {
       status shouldBe StatusCodes.Forbidden
-      entityAs[String] shouldBe "You should see this"
+    }
+  }
+
+  "Roles authorization" should {
+    val okRoute = get { complete("OK") }
+
+    "return Forbidden if no admittable roles are defined" in {
+      implicit val contexts: List[(String, String)] = List(USER_ROLES -> "a,b,c")
+
+      Get() ~> authorize()(okRoute) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+    }
+
+    "return Forbidden when there is no match between admittable roles and provided ones" in {
+      implicit val contexts: List[(String, String)] = List(USER_ROLES -> "a,b,c")
+
+      Get() ~> authorize("admin", "operator", "api")(okRoute) ~> check {
+        status shouldBe StatusCodes.Forbidden
+      }
+    }
+
+    "return the given route when there is a match between admittable roles and provided ones" in {
+      hasPermissions("hello", "admin")(Seq(USER_ROLES -> "admin,operator,api")) shouldBe true
+
+      implicit val contexts: List[(String, String)] = List(USER_ROLES -> "admin,operator,api")
+
+      Get() ~> authorize("hello", "admin")(okRoute) ~> check {
+        status shouldBe StatusCodes.OK
+      }
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -135,6 +135,7 @@ object Dependencies {
         akka.slf4j                 % Compile,
         akka.httpJson              % Compile,
         akka.httpJson4s            % Compile,
+        akka.stream                % Compile,
         spray.spray                % Compile,
         typesafe.config            % Compile,
         cats.core                  % Compile,

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/OpenapiUtils.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/OpenapiUtils.scala
@@ -34,7 +34,7 @@ trait OpenapiUtils {
       )
       .getOrElse("No request information")
 
-    logger.error("Request failed: {}", s"""$messageStrings - ["${errors.map(_.msg).mkString("""", """")}"]""")
+    logger.warn(s"""Request failed: $messageStrings - ["${errors.map(_.msg).mkString("""", """")}"]"""")
 
     errors
 

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
@@ -36,6 +36,15 @@ trait AkkaResponses {
     completeWithErrors(StatusCodes.BadRequest, errors)
   }
 
+  def unauthorized(error: ComponentError, logMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
+  ): StandardRoute = {
+    logger.warn(logMessage, error)
+    completeWithError(StatusCodes.Unauthorized, error)
+  }
+
   def notFound(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],
     logger: LoggerTakingImplicit[ContextFieldsToLog],

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
@@ -3,6 +3,7 @@ package it.pagopa.interop.commons.utils.errors
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.StandardRoute
+import cats.implicits.toFunctorFilterOps
 import com.typesafe.scalalogging.LoggerTakingImplicit
 import it.pagopa.interop.commons.logging.ContextFieldsToLog
 import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.GenericError
@@ -13,6 +14,10 @@ trait AkkaResponses {
     serviceCode: ServiceCode
   ): StandardRoute = complete(statusCode.intValue, Problem(statusCode, error, serviceCode))
 
+  private def completeWithErrors(statusCode: StatusCode, errors: List[ComponentError])(implicit
+    serviceCode: ServiceCode
+  ): StandardRoute = complete(statusCode.intValue, Problem(statusCode, errors, serviceCode))
+
   def badRequest(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],
     logger: LoggerTakingImplicit[ContextFieldsToLog],
@@ -22,15 +27,14 @@ trait AkkaResponses {
     completeWithError(StatusCodes.BadRequest, error)
   }
 
-
-//  def badRequest(errors: List[ComponentError], logMessage: String)(implicit
-//                                                            contexts: Seq[(String, String)],
-//                                                            logger: LoggerTakingImplicit[ContextFieldsToLog],
-//                                                            serviceCode: ServiceCode
-//  ): StandardRoute = {
-//    logger.warn(s"$logMessage. Reasons: ${errors.mapFilter(e => Option(e.getMessage)).mkString("[",",","]")}")
-//    completeWithError(StatusCodes.BadRequest, errors)
-//  }
+  def badRequest(errors: List[ComponentError], logMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
+  ): StandardRoute = {
+    logger.warn(s"$logMessage. Reasons: ${errors.mapFilter(e => Option(e.getMessage)).mkString("[", ",", "]")}")
+    completeWithErrors(StatusCodes.BadRequest, errors)
+  }
 
   def notFound(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
@@ -1,0 +1,49 @@
+package it.pagopa.interop.commons.utils.errors
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.StandardRoute
+import com.typesafe.scalalogging.LoggerTakingImplicit
+import it.pagopa.interop.commons.logging.ContextFieldsToLog
+import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.GenericError
+
+trait AkkaResponses {
+
+  val serviceErrorCodePrefix: String
+
+  private def completeWithError(statusCode: StatusCode, error: ComponentError): StandardRoute =
+    complete(statusCode.intValue, Problem(statusCode, error, serviceErrorCodePrefix))
+
+  def badRequest(error: ComponentError, errorMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog]
+  ): StandardRoute = {
+    logger.warn(errorMessage, error)
+    completeWithError(StatusCodes.BadRequest, error)
+  }
+
+  def notFound(error: ComponentError, errorMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog]
+  ): StandardRoute = {
+    logger.warn(errorMessage, error)
+    completeWithError(StatusCodes.NotFound, error)
+  }
+
+  def forbidden(error: ComponentError, errorMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog]
+  ): StandardRoute = {
+    logger.warn(errorMessage, error)
+    completeWithError(StatusCodes.Forbidden, error)
+  }
+
+  def internalServerError(error: Throwable, errorMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog]
+  ): StandardRoute = {
+    logger.error(errorMessage, error)
+    val statusCode = StatusCodes.InternalServerError
+    complete(statusCode.intValue, Problem(statusCode, GenericError(errorMessage), serviceErrorCodePrefix))
+  }
+}

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/AkkaResponses.scala
@@ -9,41 +9,56 @@ import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.GenericErro
 
 trait AkkaResponses {
 
-  val serviceErrorCodePrefix: String
+  private def completeWithError(statusCode: StatusCode, error: ComponentError)(implicit
+    serviceCode: ServiceCode
+  ): StandardRoute = complete(statusCode.intValue, Problem(statusCode, error, serviceCode))
 
-  private def completeWithError(statusCode: StatusCode, error: ComponentError): StandardRoute =
-    complete(statusCode.intValue, Problem(statusCode, error, serviceErrorCodePrefix))
-
-  def badRequest(error: ComponentError, errorMessage: String)(implicit
+  def badRequest(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],
-    logger: LoggerTakingImplicit[ContextFieldsToLog]
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
   ): StandardRoute = {
-    logger.warn(errorMessage, error)
+    logger.warn(logMessage, error)
     completeWithError(StatusCodes.BadRequest, error)
   }
 
-  def notFound(error: ComponentError, errorMessage: String)(implicit
+
+//  def badRequest(errors: List[ComponentError], logMessage: String)(implicit
+//                                                            contexts: Seq[(String, String)],
+//                                                            logger: LoggerTakingImplicit[ContextFieldsToLog],
+//                                                            serviceCode: ServiceCode
+//  ): StandardRoute = {
+//    logger.warn(s"$logMessage. Reasons: ${errors.mapFilter(e => Option(e.getMessage)).mkString("[",",","]")}")
+//    completeWithError(StatusCodes.BadRequest, errors)
+//  }
+
+  def notFound(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],
-    logger: LoggerTakingImplicit[ContextFieldsToLog]
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
   ): StandardRoute = {
-    logger.warn(errorMessage, error)
+    logger.warn(logMessage, error)
     completeWithError(StatusCodes.NotFound, error)
   }
 
-  def forbidden(error: ComponentError, errorMessage: String)(implicit
+  def forbidden(error: ComponentError, logMessage: String)(implicit
     contexts: Seq[(String, String)],
-    logger: LoggerTakingImplicit[ContextFieldsToLog]
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
   ): StandardRoute = {
-    logger.warn(errorMessage, error)
+    logger.warn(logMessage, error)
     completeWithError(StatusCodes.Forbidden, error)
   }
 
   def internalServerError(error: Throwable, errorMessage: String)(implicit
     contexts: Seq[(String, String)],
-    logger: LoggerTakingImplicit[ContextFieldsToLog]
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    serviceCode: ServiceCode
   ): StandardRoute = {
     logger.error(errorMessage, error)
     val statusCode = StatusCodes.InternalServerError
-    complete(statusCode.intValue, Problem(statusCode, GenericError(errorMessage), serviceErrorCodePrefix))
+    complete(statusCode.intValue, Problem(statusCode, GenericError(errorMessage), serviceCode))
   }
 }
+
+object AkkaResponses extends AkkaResponses

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
@@ -33,4 +33,17 @@ object Problem extends SprayJsonSupport with DefaultJsonProtocol {
       )
     )
 
+  def apply(httpError: StatusCode, errors: List[ComponentError], serviceCode: ServiceCode): Problem =
+    Problem(
+      `type` = defaultProblemType,
+      status = httpError.intValue,
+      title = httpError.defaultMessage,
+      errors = errors.map(error =>
+        ProblemError(
+          code = s"${serviceCode.code}-${error.code}",
+          detail = Option(error.getMessage).getOrElse(defaultErrorMessage)
+        )
+      )
+    )
+
 }

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
@@ -1,0 +1,34 @@
+package it.pagopa.interop.commons.utils.errors
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import akka.http.scaladsl.model.StatusCode
+import spray.json._
+
+final case class Problem(
+  `type`: String,
+  status: Int,
+  title: String,
+  detail: Option[String] = None,
+  errors: Seq[ProblemError]
+)
+
+object Problem extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit def problemFormat: RootJsonFormat[Problem] = jsonFormat5(Problem.apply)
+  implicit def toEntityMarshallerProblem: ToEntityMarshaller[Problem] = sprayJsonMarshaller[Problem]
+
+  final val defaultProblemType: String  = "about:blank"
+  final val defaultErrorMessage: String = "Unknown error"
+
+  def apply(httpError: StatusCode, error: ComponentError, serviceErrorCodePrefix: String): Problem = Problem(
+    `type` = defaultProblemType,
+    status = httpError.intValue,
+    title = httpError.defaultMessage,
+    errors = Seq(
+      ProblemError(
+        code = s"$serviceErrorCodePrefix-${error.code}",
+        detail = Option(error.getMessage).getOrElse(defaultErrorMessage)
+      )
+    )
+  )
+}

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/Problem.scala
@@ -14,21 +14,23 @@ final case class Problem(
 )
 
 object Problem extends SprayJsonSupport with DefaultJsonProtocol {
-  implicit def problemFormat: RootJsonFormat[Problem] = jsonFormat5(Problem.apply)
+  implicit def problemFormat: RootJsonFormat[Problem]                 = jsonFormat5(Problem.apply)
   implicit def toEntityMarshallerProblem: ToEntityMarshaller[Problem] = sprayJsonMarshaller[Problem]
 
   final val defaultProblemType: String  = "about:blank"
   final val defaultErrorMessage: String = "Unknown error"
 
-  def apply(httpError: StatusCode, error: ComponentError, serviceErrorCodePrefix: String): Problem = Problem(
-    `type` = defaultProblemType,
-    status = httpError.intValue,
-    title = httpError.defaultMessage,
-    errors = Seq(
-      ProblemError(
-        code = s"$serviceErrorCodePrefix-${error.code}",
-        detail = Option(error.getMessage).getOrElse(defaultErrorMessage)
+  def apply(httpError: StatusCode, error: ComponentError, serviceCode: ServiceCode): Problem =
+    Problem(
+      `type` = defaultProblemType,
+      status = httpError.intValue,
+      title = httpError.defaultMessage,
+      errors = Seq(
+        ProblemError(
+          code = s"${serviceCode.code}-${error.code}",
+          detail = Option(error.getMessage).getOrElse(defaultErrorMessage)
+        )
       )
     )
-  )
+
 }

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/ProblemError.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/ProblemError.scala
@@ -1,0 +1,10 @@
+package it.pagopa.interop.commons.utils.errors
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+
+final case class ProblemError(code: String, detail: String)
+
+object ProblemError extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit def problemErrorFormat: RootJsonFormat[ProblemError] = jsonFormat2(ProblemError.apply)
+}

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/ServiceCode.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/errors/ServiceCode.scala
@@ -1,0 +1,3 @@
+package it.pagopa.interop.commons.utils.errors
+
+final case class ServiceCode(code: String) extends AnyVal


### PR DESCRIPTION
- Created common `Problem` with required codecs
- Created helpers for error responses (log included)
- Moved to commons function that contains authorization logic
- Lowered log level from error to warning when required