### PR TITLE
Adding close method to file manager

### DIFF
--- a/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/FileManager.scala
+++ b/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/FileManager.scala
@@ -28,6 +28,8 @@ trait FileManager {
   def get(containerPath: String)(filePath: StorageFilePath): Future[ByteArrayOutputStream]
 
   def delete(containerPath: String)(filePath: StorageFilePath): Future[Boolean]
+
+  def close(): Unit
 }
 
 object FileManager {

--- a/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/impl/FileManagerImpl.scala
+++ b/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/impl/FileManagerImpl.scala
@@ -9,6 +9,8 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 
 final class FileManagerImpl(blockingExecutionContext: ExecutionContextExecutor) extends FileManager {
 
+  override def close(): Unit = ()
+
   implicit val ec: ExecutionContextExecutor = blockingExecutionContext
 
   val tmp: Path = Path.of("/tmp")

--- a/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/impl/S3ManagerImpl.scala
+++ b/file-manager/src/main/scala/it/pagopa/interop/commons/files/service/impl/S3ManagerImpl.scala
@@ -42,6 +42,8 @@ final class S3ManagerImpl(blockingExecutionContext: ExecutionContextExecutor) ex
     .asyncConfiguration(asyncConfiguration)
     .build()
 
+  override def close(): Unit = asyncClient.close()
+
   private def s3Key(path: String, resourceId: String, fileName: String): String =
     s"$path/$resourceId/$fileName"
 


### PR DESCRIPTION
Another resource that possibly remains hung when a job is completed. I exposed the close method to close the eventual undelying client.
