### PR TITLE
Mantaining message ordering while reading/writing queues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ lazy val queue = project
     sharedSettings,
     libraryDependencies ++= Dependencies.Jars.queueDependencies
   )
+  .dependsOn(utils)
   .setupBuildInfo
 
 lazy val cqrs = project

--- a/utils/src/main/scala/it/pagopa/interop/commons/utils/TypeConversions.scala
+++ b/utils/src/main/scala/it/pagopa/interop/commons/utils/TypeConversions.scala
@@ -118,6 +118,14 @@ object TypeConversions {
     def parCollectWithLatch[T, V](n: Int)(list: List[T])(f: T => Future[V])(implicit
       ec: ExecutionContext
     ): Future[List[V]] = parTraverseWithLatch(n)(list)(f).map(_.collect { case Some(v) => v })
+
+    def sequentially[T, V](list: List[T])(f: T => Future[V])(implicit ec: ExecutionContext): Future[List[V]] = {
+      def go(innerList: List[T])(acc: List[V]): Future[List[V]] = innerList match {
+        case head :: next => f(head).flatMap(v => go(next)(acc :+ v))
+        case Nil          => Future.successful(acc)
+      }
+      go(list)(Nil)
+    }
   }
 
 }


### PR DESCRIPTION
I simply replaced some Future.traverse with Future.sequence here and there.
Also I removed any use of cats with futures in the same module.
