### PR TITLE
Fixed WSDL parsing

### DIFF
--- a/parser/src/test/resources/api_without_binding.wsdl
+++ b/parser/src/test/resources/api_without_binding.wsdl
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestWS" targetNamespace="http://host/TestWS" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:i0="http://tempuri.org/" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://host/TestWS" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://host/TestWS" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:include schemaLocation="TestWS.xsd"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="One_InputMessage">
+    <wsdl:part name="parameters" element="tns:One"/>
+  </wsdl:message>
+  <wsdl:message name="One_InputMessage">
+    <wsdl:part name="parameters" element="tns:OneResponse"/>
+  </wsdl:message>
+  <wsdl:message name="Two_InputMessage">
+    <wsdl:part name="parameters" element="tns:Two"/>
+  </wsdl:message>
+  <wsdl:message name="Two_OutputMessage">
+    <wsdl:part name="parameters" element="tns:TwoResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="TestWS">
+    <wsdl:operation name="One">
+      <wsdl:input message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/One"/>
+      <wsdl:output message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/OneResponse"/>
+    </wsdl:operation>
+    <wsdl:operation name="Two">
+      <wsdl:input message="tns:Two_InputMessage" wsaw:Action="http://host/TestWS/Two"/>
+      <wsdl:output message="tns:Two_OutputMessage" wsaw:Action="http://host/TestWS/TwoResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:service name="TestWS">
+    <wsdl:port name="TestWS" binding="tns:TestWS">
+      <soap:address location="https://host.com/TestWS/v1"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/parser/src/test/resources/api_without_service.wsdl
+++ b/parser/src/test/resources/api_without_service.wsdl
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="TestWS" targetNamespace="http://host/TestWS" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:i0="http://tempuri.org/" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://host/TestWS" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+  <wsdl:types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://host/TestWS" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <xs:include schemaLocation="TestWS.xsd"/>
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="One_InputMessage">
+    <wsdl:part name="parameters" element="tns:One"/>
+  </wsdl:message>
+  <wsdl:message name="One_InputMessage">
+    <wsdl:part name="parameters" element="tns:OneResponse"/>
+  </wsdl:message>
+  <wsdl:message name="Two_InputMessage">
+    <wsdl:part name="parameters" element="tns:Two"/>
+  </wsdl:message>
+  <wsdl:message name="Two_OutputMessage">
+    <wsdl:part name="parameters" element="tns:TwoResponse"/>
+  </wsdl:message>
+  <wsdl:portType name="TestWS">
+    <wsdl:operation name="One">
+      <wsdl:input message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/One"/>
+      <wsdl:output message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/OneResponse"/>
+    </wsdl:operation>
+    <wsdl:operation name="Two">
+      <wsdl:input message="tns:Two_InputMessage" wsaw:Action="http://host/TestWS/Two"/>
+      <wsdl:output message="tns:Two_OutputMessage" wsaw:Action="http://host/TestWS/TwoResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="TestWS" type="tns:TestWS">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="One">
+      <soap:operation soapAction="http://host/TestWS/One" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="Two">
+      <soap:operation soapAction="http://host/TestWS/Two" style="document"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+</wsdl:definitions>

--- a/parser/src/test/scala/it/pagopa/interop/commons/parser/InterfaceParserUtilsSpec.scala
+++ b/parser/src/test/scala/it/pagopa/interop/commons/parser/InterfaceParserUtilsSpec.scala
@@ -244,6 +244,24 @@ class InterfaceParserUtilsSpec extends AnyWordSpecLike with Matchers {
       result.isLeft shouldBe true
     }
 
+    "fail extracting urls from a w/o service" in {
+      val bytes: Array[Byte] = Source.fromResource("api_without_service.wsdl").getLines().mkString("\n").getBytes
+      val parsed: Either[Throwable, Elem] = InterfaceParser.parseWSDL(bytes)
+
+      val result: Either[Throwable, List[String]] = parsed.flatMap(InterfaceParserUtils.getUrls[Elem])
+
+      result.isLeft shouldBe true
+    }
+
+    "fail extracting endpoints from a w/o binding" in {
+      val bytes: Array[Byte] = Source.fromResource("api_without_binding.wsdl").getLines().mkString("\n").getBytes
+      val parsed: Either[Throwable, Elem] = InterfaceParser.parseWSDL(bytes)
+
+      val result: Either[Throwable, List[String]] = parsed.flatMap(InterfaceParserUtils.getEndpoints[Elem])
+
+      result.isLeft shouldBe true
+    }
+
     "extract endpoints from a WSDL correctly" in {
       val bytes: Array[Byte]              = Source.fromResource("api.wsdl").getLines().mkString("\n").getBytes
       val parsed: Either[Throwable, Elem] = InterfaceParser.parseWSDL(bytes)


### PR DESCRIPTION
This PR should fix the parsing of wsdl that led to incorrect wsdl being uploaded on our platform. 

The two test I wrote are not passing using the legacy code, meaning that is completely possible to upload wsdl w/o `service` or `binding` object since those methods were merely returning an empty list.

The technical reason is that `/` returns a `NodeSeq.Empty` when the parsing fails (e.g. when the node is missing) and the successive `.toList.traverse(...)` was doing its job of returning a `Nil`.