### PR TITLE
Resilient parsing

### DIFF
--- a/parser/src/main/scala/it/pagopa/interop/commons/parser/InterfaceParserUtils.scala
+++ b/parser/src/main/scala/it/pagopa/interop/commons/parser/InterfaceParserUtils.scala
@@ -62,7 +62,9 @@ object InterfaceParserUtils {
         .asRight[Throwable]
         .ensure(Errors.InterfaceExtractingInfoError)(_.nonEmpty)
         .flatMap(
-          _.traverse(node => node.attribute("location").map(_.text).toRight(Errors.InterfaceExtractingInfoError))
+          _.traverse(node =>
+            node.attribute("location").map(_.text).filterNot(_.isBlank).toRight(Errors.InterfaceExtractingInfoError)
+          )
         )
 
     override def getEndpoints(xml: Elem): Either[Throwable, List[String]] = {
@@ -72,7 +74,7 @@ object InterfaceParserUtils {
 
       def getSoapActionName(node: Node): Either[Throwable, List[String]] =
         (node \ "operation").toList.traverse(
-          _.attribute("soapAction").map(_.text).toRight(Errors.InterfaceExtractingInfoError)
+          _.attribute("soapAction").map(_.text).filterNot(_.isBlank).toRight(Errors.InterfaceExtractingInfoError)
         )
 
       def getName(node: Node): Either[Throwable, List[String]] =

--- a/parser/src/main/scala/it/pagopa/interop/commons/parser/InterfaceParserUtils.scala
+++ b/parser/src/main/scala/it/pagopa/interop/commons/parser/InterfaceParserUtils.scala
@@ -5,7 +5,7 @@ import io.circe.{DecodingFailure, Json}
 import it.pagopa.interop.commons.parser.errors.Errors
 import it.pagopa.interop.commons.parser.errors.Errors.OpenapiVersionNotRecognized
 
-import scala.xml.Elem
+import scala.xml.{Elem, Node}
 
 trait InterfaceParserUtils[A] {
   def getUrls(serviceInterface: A): Either[Throwable, List[String]]
@@ -65,11 +65,21 @@ object InterfaceParserUtils {
           _.traverse(node => node.attribute("location").map(_.text).toRight(Errors.InterfaceExtractingInfoError))
         )
 
-    override def getEndpoints(xml: Elem): Either[Throwable, List[String]] =
-      (xml \\ "definitions" \ "binding" \ "operation" \ "operation").toList
+    override def getEndpoints(xml: Elem): Either[Throwable, List[String]] = {
+      val operationNodes: Either[Throwable, List[Node]] = (xml \\ "definitions" \ "binding" \ "operation").toList
         .asRight[Throwable]
         .ensure(Errors.InterfaceExtractingInfoError)(_.nonEmpty)
-        .flatMap(_.traverse(_.attribute("soapAction").map(_.text).toRight(Errors.InterfaceExtractingInfoError)))
+
+      def getSoapActionName(node: Node): Either[Throwable, List[String]] =
+        (node \ "operation").toList.traverse(
+          _.attribute("soapAction").map(_.text).toRight(Errors.InterfaceExtractingInfoError)
+        )
+
+      def getName(node: Node): Either[Throwable, List[String]] =
+        node.attribute("name").map(n => n.text :: Nil).toRight(Errors.InterfaceExtractingInfoError)
+
+      operationNodes.flatMap(nodes => nodes.flatTraverse(getSoapActionName).orElse(nodes.flatTraverse(getName)))
+    }
   }
 
 }

--- a/parser/src/test/resources/api_without_soapAction.wsdl
+++ b/parser/src/test/resources/api_without_soapAction.wsdl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="TestWS" targetNamespace="http://host/TestWS" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:i0="http://tempuri.org/" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://host/TestWS" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+        <wsdl:types>
+                <xs:schema elementFormDefault="qualified" targetNamespace="http://host/TestWS" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                        <xs:include schemaLocation="TestWS.xsd"/>
+                </xs:schema>
+        </wsdl:types>
+        <wsdl:message name="One_InputMessage">
+                <wsdl:part name="parameters" element="tns:One"/>
+        </wsdl:message>
+        <wsdl:message name="One_InputMessage">
+                <wsdl:part name="parameters" element="tns:OneResponse"/>
+        </wsdl:message>
+        <wsdl:message name="Two_InputMessage">
+                <wsdl:part name="parameters" element="tns:Two"/>
+        </wsdl:message>
+        <wsdl:message name="Two_OutputMessage">
+                <wsdl:part name="parameters" element="tns:TwoResponse"/>
+        </wsdl:message>
+        <wsdl:portType name="TestWS">
+                <wsdl:operation name="One">
+                        <wsdl:input message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/One"/>
+                        <wsdl:output message="tns:One_InputMessage" wsaw:Action="http://host/TestWS/OneResponse"/>
+                </wsdl:operation>
+                <wsdl:operation name="Two">
+                        <wsdl:input message="tns:Two_InputMessage" wsaw:Action="http://host/TestWS/Two"/>
+                        <wsdl:output message="tns:Two_OutputMessage" wsaw:Action="http://host/TestWS/TwoResponse"/>
+                </wsdl:operation>
+        </wsdl:portType>
+        <wsdl:binding name="TestWS" type="tns:TestWS">
+                <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                <wsdl:operation name="One">
+                        <soap:operation soapAction="" style="document"/>
+                        <wsdl:input>
+                                <soap:body use="literal"/>
+                        </wsdl:input>
+                        <wsdl:output>
+                                <soap:body use="literal"/>
+                        </wsdl:output>
+                </wsdl:operation>
+                <wsdl:operation name="Two">
+                        <soap:operation soapAction="" style="document"/>
+                        <wsdl:input>
+                                <soap:body use="literal"/>
+                        </wsdl:input>
+                        <wsdl:output>
+                                <soap:body use="literal"/>
+                        </wsdl:output>
+                </wsdl:operation>
+        </wsdl:binding>
+        <wsdl:service name="TestWS">
+                <wsdl:port name="TestWS" binding="tns:TestWS">
+                        <soap:address location="https://host.com/TestWS/v1"/>
+                </wsdl:port>
+        </wsdl:service>
+</wsdl:definitions>

--- a/parser/src/test/scala/it/pagopa/interop/commons/parser/InterfaceParserUtilsSpec.scala
+++ b/parser/src/test/scala/it/pagopa/interop/commons/parser/InterfaceParserUtilsSpec.scala
@@ -270,5 +270,14 @@ class InterfaceParserUtilsSpec extends AnyWordSpecLike with Matchers {
 
       result shouldBe Right(List("http://host/TestWS/One", "http://host/TestWS/Two"))
     }
+
+    "extract endpoints from a WSDL without soapName attribute" in {
+      val bytes: Array[Byte] = Source.fromResource("api_without_soapAction.wsdl").getLines().mkString("\n").getBytes
+      val parsed: Either[Throwable, Elem] = InterfaceParser.parseWSDL(bytes)
+
+      val result: Either[Throwable, List[String]] = parsed.flatMap(InterfaceParserUtils.getEndpoints[Elem])
+
+      result shouldBe Right(List("One", "Two"))
+    }
   }
 }


### PR DESCRIPTION
This modification makes the PA Digitale job run again. The parsing tries to get the endpoint information from the top level element when the soapName is not present in the child node. If the information is used to determine the number of unique operation in the wsdl, then there's no problem.